### PR TITLE
fix (electron-chrome-extensions): native messaging disconnect port on destroy

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/lib/native-messaging-host.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/lib/native-messaging-host.ts
@@ -125,7 +125,6 @@ export class NativeMessagingHost {
   }
 
   destroy() {
-    if (!this.connected) return
     this.connected = false
     if (this.process) {
       this.process.kill()

--- a/packages/electron-chrome-extensions/src/renderer/index.ts
+++ b/packages/electron-chrome-extensions/src/renderer/index.ts
@@ -67,7 +67,7 @@ export const injectExtensionAPIs = () => {
       receive(message)
     }
     ipcRenderer.on(`crx-native-msg-${connectionId}`, onMessage)
-    ipcRenderer.once(`crx-native-msg-${connectNative}-disconnect`, () => {
+    ipcRenderer.once(`crx-native-msg-${connectionId}-disconnect`, () => {
       ipcRenderer.off(`crx-native-msg-${connectionId}`, onMessage)
       disconnect()
     })


### PR DESCRIPTION
- **fix (electron-chrome-extensions): fix typo on native msg disconnect ipc channel name**
- **fix (electron-chrome-extensions): send native disconnect message regardless of native messaging host connection status**
